### PR TITLE
Update case list page and filters, tab overview

### DIFF
--- a/app/assets/sass/_case-filter.scss
+++ b/app/assets/sass/_case-filter.scss
@@ -37,7 +37,7 @@
 .mspsds-case-filter-controls {
   
   .govuk-form-group {
-    margin-bottom: govuk-spacing(0);
+    // margin-bottom: govuk-spacing(0);
   }
 
   select {

--- a/app/assets/sass/_facet-tags.scss
+++ b/app/assets/sass/_facet-tags.scss
@@ -1,0 +1,127 @@
+// Stolen from:
+// https://github.com/alphagov/finder-frontend/blob/5b60de9300069f569f008d432fde2d6f7a11529f/app/assets/stylesheets/finder_frontend.scss#L254
+
+.facet-tags {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(6);
+  }
+
+  .facet-tags__group {
+    padding: 5px;
+
+    &:nth-child(odd) {
+      background-color: govuk-colour("grey-4");
+    }
+  }
+
+  .facet-tags__wrapper {
+    vertical-align: middle;
+    margin: 5px 0;
+
+    @include govuk-media-query($from: tablet) {
+      display: inline-block;
+    }
+  }
+
+  .facet-tags__wrapper:first-of-type .facet-tags__preposition:first-of-type {
+    // font-weight: bold;
+
+    &::first-letter {
+      text-transform: uppercase;
+    }
+  }
+
+  .facet-tags__preposition {
+    padding: 0 5px 5px 2px;
+    vertical-align: middle;
+    text-transform: lowercase;
+
+    @include govuk-media-query($from: tablet) {
+      display: table-cell;
+      padding: 0 5px 0 2px;
+    }
+  }
+
+  .facet-tag {
+    display: block;
+    position: relative;
+    padding: 5px;
+    border: 1px solid govuk-colour("grey-1");
+    border-radius: 5px;
+    background-color: govuk-colour("grey-4");
+
+    .js-enabled & {
+      padding: 8px 7px 7px 23px;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      display: table-cell;
+    }
+  }
+
+  .facet-tag__text {
+    display: inline-block;
+    margin-left: 0;
+    margin-bottom: 0;
+
+    .js-enabled & {
+      margin-left: 5px;
+    }
+  }
+
+  .facet-tag__remove {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    padding: 8px;
+    border-radius: 5px;
+    font-weight: bold;
+    @include govuk-font(16, $weight: bold);
+    text-align: left;
+    cursor: pointer;
+    color: #000;
+    text-decoration: none;
+    background: none;
+    border: 0;
+
+    .js-enabled & {
+      display: inline-block;
+    }
+  }
+
+
+.facet-toggle {
+  display: none;
+  margin-bottom: govuk-spacing(6);
+}
+
+.js-enabled {
+  .facet-toggle {
+    display: inline-block;
+  }
+
+  .facet-toggle__content {
+    display: block;
+
+    &.facet-toggle__content--hide {
+      display: none;
+    }
+  }
+
+  .facet-toggle--only-on-mobile {
+    .facet-toggle {
+      @include govuk-media-query($from: tablet) {
+        display: none;
+      }
+    }
+
+    .facet-toggle__content.facet-toggle__content--hide {
+      @include govuk-media-query($from: tablet) {
+        display: block;
+      }
+    }
+  }
+}

--- a/app/assets/sass/_search.scss
+++ b/app/assets/sass/_search.scss
@@ -1,7 +1,7 @@
 .mspsds-search {
 
     position: relative;
-    @include govuk-responsive-margin(2, "bottom");
+    // @include govuk-responsive-margin(2, "bottom");
 
     &__submit {
         position:   absolute;
@@ -19,7 +19,7 @@
     }
 
     &--left {
-        @include govuk-responsive-margin(6, "bottom");
+        // @include govuk-responsive-margin(6, "bottom");
     }
 
     &__label {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -29,6 +29,7 @@ $govuk-page-width: 1200px;
 @import "hmcts-identity-bar";
 @import "hmcts-sub-navigation";
 @import "interruption-card";
+@import "facet-tags";
 @import "teams";
 @import "footer";
 @import "email-message";
@@ -98,7 +99,13 @@ div[class^="govuk-grid-column-"] img {
 
 
 .align-right {
-  float: right;
+  // float: right;
+}
+
+.align-right {
+  @include mq($from: tablet) {
+    float: right;
+  }
 }
 
 .button-inline {
@@ -108,11 +115,11 @@ div[class^="govuk-grid-column-"] img {
 }
 
 // Set case list to be wider
-// .case-list {
-//   & .govuk-width-container, & .hmcts-primary-navigation__container {
-//     max-width: 1200px;
-//   } 
-// }
+.case-list {
+  & .govuk-width-container, & .hmcts-primary-navigation__container {
+    max-width: 1200px;
+  } 
+}
 
 // todo: should we do something like this?: https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/main.scss#L69
 p.govuk-body, h1, h2, h3 {
@@ -125,3 +132,29 @@ p.govuk-body, h1, h2, h3 {
   @include govuk-responsive-padding(6);
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
+.mspsds-case-filter-controls__container {
+  // @include govuk-responsive-padding(3);
+  box-shadow: inset 0 0 0 1px govuk-colour("grey-3");
+}
+
+.mspsds-case-filter-controls__heading {
+  background-color: govuk-colour("grey-3");
+  @include govuk-responsive-padding(3);
+  // @include govuk-responsive-padding(3, "left");
+  // @include govuk-responsive-padding(3, "right");
+
+  // padding-top: 0;
+  margin-bottom: 0;
+}
+
+.mspsds-case-filter-controls__filters-container {
+  @include govuk-responsive-padding(3);
+}
+
+.mspsds-case-filter-controls {
+  border-right: 1px solid govuk-colour("grey-3");
+}

--- a/app/views/includes/components/case/case-card-list.html
+++ b/app/views/includes/components/case/case-card-list.html
@@ -1,8 +1,101 @@
 {% from "includes/components/case/case-card.html"         import caseCard %}
-
-{% macro caseCardList(cases, currentTeam = "", searchResult = false) %}
+{% from "table/macro.njk" import govukTable %}
+{# {% macro caseCardList(cases, currentTeam = "", searchResult = false) %}
   {% for case in cases %}
     {{ caseCard(case, searchResult, currentTeam) }}
   {% endfor %}
+
+{% endmacro %} #}
+
+
+{% macro caseCardList(cases, currentTeam = "", searchResult = false) %}
+{#   {% for case in cases %}
+    {{ caseCard(case, searchResult, currentTeam) }}
+  {% endfor %} #}
+
+  {% set caseRows = [] %}
+
+  {% for case in cases %}
+
+    {% set caseTitle -%}
+
+      {%- if case.type == "Question" -%}
+         {{- case.title | safe -}}
+      {%- endif -%}
+
+      {%- if case.products | length > 0 -%}
+        {{- " " + case.products[0].name -}}
+      {%- else -%}
+        {{- " undefined product" -}}
+      {%- endif -%}
+
+      {%- if case.type == 'Case' -%}
+        {%- if case.report.hazardType -%}
+          {{- " " + case.report.hazardType -}}
+        {%- else -%}
+          {{- " undefined hazard" -}}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endset %}
+    
+    {% set caseIdLink %}
+    <a href="case?caseid={{case.id}}&currentPage=case&productid=&businessid" class="govuk-link no-wrap">{{case.id}}</a>
+    {% endset %}
+    {% set caseTitleLink %}
+    <a href="case?caseid={{case.id}}&currentPage=case&productid=&businessid" class="govuk-link">{{caseTitle}}</a>
+    {% endset %}
+    {% set caseViewLink %}
+    <a href="case?caseid={{case.id}}&currentPage=case&productid=&businessid" class="govuk-link">View</a>
+    {% endset %}
+
+    {% set row = [
+      {text:case.id,
+        classes: "no-wrap"},
+      {text:caseTitle},
+      {text:case.report.reporter.name},
+      {text:case.assignee},
+      {text:case.dateUpdated | prettifyDate},
+      {text:caseViewLink | safe}
+      ] %}
+
+    {% set titleHTML -%}
+      {{caseTitleLink | safe}}
+      <span class="govuk-hint govuk-!-font-size-16">{{case.id}} – {{case.type}}</span>
+    {%- endset %}
+
+    {#  {text:case.report.reporter.name}, #}
+
+    {% set row = [
+      {html: titleHTML },
+      {text:case.assignee},
+      {text:case.dateUpdated | prettifyDate}
+      ] %}
+
+    {% set caseRows = (caseRows.push(row), caseRows) %}
+
+  {% endfor %}
+
+  {# {
+        text: "Created by",
+        classes: "no-wrap"
+      }, #}
+
+  {{ govukTable({
+    firstCellIsHeader: false,
+    head: [
+
+      {
+        text: "Case"
+      },
+      {
+        text: "Assigned to",
+        classes: "no-wrap"
+      },
+      {
+        text: "Updated"
+      }
+    ],
+    rows: caseRows
+  }) }}
 
 {% endmacro %}

--- a/app/views/includes/components/shared/tab-title.html
+++ b/app/views/includes/components/shared/tab-title.html
@@ -1,10 +1,9 @@
 {% macro tabTitle(titleData) %}
-    <div class="mspsds-tab__title govuk-!-margin-bottom-6">
-        <h2 class="govuk-heading-l govuk-!-margin-bottom-1">{{titleData.title}}</h2>
+    <div class="mspsds-tab__title">
+        <h2 class="govuk-heading-m">{{titleData.title}}</h2>
         
         {% if titleData.controls %}
             {{titleData.controls | safe}}
         {% endif %}
     </div>
 {% endmacro %}
-x§

--- a/app/views/includes/components/shared/tabs/tab-overview.html
+++ b/app/views/includes/components/shared/tabs/tab-overview.html
@@ -1,70 +1,108 @@
 {% from "includes/components/shared/tab-title.html"                 import tabTitle %}
 {% from "details/macro.njk"                                         import govukDetails %}
 
-{{ tabTitle({
-  title:      'Summary'
-}) }}
+{% set hasEditRights = true if (currentCase.assignee == data['currentUser']) else false %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    {{ tabTitle({
+      title:      'Summary'
+    }) }}
+
     <p class="govuk-body">{{currentCase.report.summary}}</p>
+    {% if hasEditRights %}
     <p class="govuk-body">
-      <a class="govuk-link govuk-link--no-visited-state" href="/pages/flows/summary/edit/01">Edit summary</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="/pages/flows/summary/edit/01">
+        Edit summary
+      </a>
     </p>
+    {% endif %}
   </div>
-  
 </div>
-<hr class="govuk-section-break govuk-section-break--m" />
 
-{{ tabTitle({
-  title:      'Current status'
-}) }}
+{% set significantDateLabel = "Last updated" if currentCase.activities.length > 1 else "Created" %}
+
 <div class="govuk-grid-row">
-{% if data['currentTeam'] == 'Trading Standards' %}
 
-  {% set significantDateLabel = "Last updated" if currentCase.activities.length > 1 else "Created" %}
-  <div class="govuk-grid-column-two-thirds">
-    {{ govukTable({
-      classes: "mspsds-case-status",
-      firstCellIsHeader: true,
+{# {% if currentCase.assignee == data['currentUser'] %} #}
+
+{# {% if data['currentTeam'] == 'Trading Standards' %} #}
+
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+
+    {{ tabTitle({
+      title:      'Current status'
+    }) }}
+
+    {{ govukSummaryList({
+      classes: "govuk-!-margin-bottom-6",
       rows: [
-        [
-          { html: '<span class="govuk-caption-m govuk-!-font-size-16">Status</span> ' + currentCase.status  }
-        ],
-        [
-          { html: '<span class="govuk-caption-m govuk-!-font-size-16">Assigned to</span>' + currentCase.assignee }
-        ],
-        [
-          { html: '<span class="govuk-caption-m govuk-!-font-size-16">'+significantDateLabel+'</span>' + currentCase.dateUpdated | prettifyDate }
-        ]
+      {
+          key: {
+            text: "Status"
+          },
+          value: {
+            text: currentCase.status
+          },
+          actions: {
+            items: [
+              {
+                href: "/root/flows/change-status/01",
+                text: "Change",
+                visuallyHiddenText: "case status",
+                classes: "govuk-link--no-visited-state" 
+              } if hasEditRights else []
+            ]
+
+          }
+        },
+        {
+          key: {
+            text: "Assigned to" if (currentCase.status=="Open") else "Owner"
+          },
+          value: {
+            text: currentCase.assignee
+          },
+          actions: {
+            items: [
+              {
+                href: "/root/flows/assign/01",
+                text: "Change",
+                visuallyHiddenText: "assignee",
+                classes: "govuk-link--no-visited-state" 
+              } if hasEditRights else []
+            ]
+          }
+        },
+        {
+          key: {
+            text: significantDateLabel
+          },
+          value: {
+            text: currentCase.dateUpdated | prettifyDate
+          },
+          actions: {
+            items: [
+              {
+                href: "/root/flows/add-activity/01?currentPage=case&caseid="+currentCase.id,
+                text: "Add activity",
+                classes: "govuk-link--no-visited-state" 
+              }
+            ]
+          } if hasEditRights else {
+          items: [
+              {
+                href: "/root/flows/add-comment/01-add-comment",
+                text: "Add comment"
+              }
+            ]
+        }
+        }
       ]
     }) }}
   </div>
 
-{% else %}
-
-    <div class="govuk-grid-column-one-half">
-        {{ govukTable({
-          classes: "mspsds-case-status",
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { html: '<span class="govuk-caption-m govuk-!-font-size-16">Status</span> ' + currentCase.status  },
-              { html: '<a href="/root/flows/change-status/01" class="govuk-!-font-size-16">Change</a>'}
-            ],
-            [
-              { html: '<span class="govuk-caption-m govuk-!-font-size-16">Assigned to</span>' + currentCase.assignee },
-              { html: '<a href="/root/flows/assign/01" class="govuk-!-font-size-16">Change</a>' }
-            ],
-            [
-              { html: '<span class="govuk-caption-m govuk-!-font-size-16">Last updated</span>' + currentCase.dateUpdated | prettifyDate },
-              { html: '<a href="/root/flows/add-activity/01?currentPage=case&caseid='+currentCase.id+'" class="govuk-!-font-size-16">Add activity</a>' }
-            ]
-          ]
-        }) }}
-    </div>
-
-{% endif %}
 </div>
 <hr class="govuk-section-break govuk-section-break--m" />
 

--- a/app/views/includes/header-search.html
+++ b/app/views/includes/header-search.html
@@ -1,10 +1,10 @@
 {% macro headerSearch(options) %}
 
 	<form id="search" class="mspsds-search govuk-form-group {{options.classes}}" action="{{options.action}}" method="get" role="search">
-	    <div class="mspsds-search__content">
+	    <div class="mspsds-search__content govuk-form-group">
 	      <label for="mspsds-search__input" class="mspsds-search__label govuk-label govuk-label--s" >{{options.label}}</label>
 	      <input type="search" name="q" id="mspsds-search__input" title="Search" class="js-search-focus govuk-input" value="{{options.value}}">
-	      <input class="submit mspsds-search__submit" type="submit" value="Search">
+	      <input class="submit mspsds-search__submit" type="submit" hidden value="Search">
 	    </div>
 	</form>
 

--- a/app/views/includes/tab-title.html
+++ b/app/views/includes/tab-title.html
@@ -1,6 +1,6 @@
 {% macro tabTitle(titleData) %}
-    <div class="mspsds-tab__title govuk-!-margin-bottom-6">
-        <h2 class="govuk-heading-l govuk-!-margin-bottom-1">{{titleData.title}}</h2>
+    <div class="mspsds-tab__title">
+        <h2 class="govuk-heading-m">{{titleData.title}}</h2>
         
         {% if titleData.controls %}
             {{titleData.controls | safe}}

--- a/app/views/includes/templates/case-list.html
+++ b/app/views/includes/templates/case-list.html
@@ -8,12 +8,12 @@
 {% set currentTeam   = data['currentTeam'] %}
 
 {% if currentTeam.includes("Trading") %}
-  {% set createLink   = '/pages/flows/ts-create/product-details' %}
-  {% set settings     = data.tsCaseListSettings  %}
-
-{% else %}
-  {% set createLink  = data['createUrl'] %}
+  {% set createLink   = '/root/flows/ts-create/product-details' %}
   {% set settings     = data.caseListSettings  %}
+
+{# {% else %}
+  {% set createLink  = data['createUrl'] %}
+  {% set settings     = data.caseListSettings  %} #}
 
 {% endif %}
 
@@ -41,38 +41,10 @@
 
 {% block beforeContent %}
 
-    {# {% include "includes/components/shared/page-banner.html" %} #}
-
-    {# {% from "includes/components/shared/site-nav.html"        import siteNav %}
-    {{ siteNav([
-      {
-        label: 'Home',
-        link: '/root/home'
-      }, {
-        label: 'Cases',
-        link: '/root/case-list',
-        classes: 'active'
-      }, {
-        label: 'Products',
-        link: '/root/product-list'
-      }, {
-        label: 'Businesses',
-        link: '/root/business-list'
-      },{ 
-      label: 'Your teams',
-      link: '/pages/your-teams',
-      classes: 'menu-right'
-    }
-    ] ) }} #}
-
 {% endblock %}
 
-
-
-
-
-
 {% block content %}
+
 
   {% block pageHeader %}
   <div class="govuk-grid-row">
@@ -83,207 +55,224 @@
     </div>
     <div class="govuk-grid-column-one-third">
       <div class="align-right" data-create="{{create}}">
-        {{ govukButton({
-          text: "Create new",
-          href: createLink,
-          classes: "govuk-button"
-        }) }}
+        <form action="{{createLink}}" method="post" class="form">
+
+        {% include "includes/components/shared/create/ts-setup-prototype-data.html" %}
+
+          {{ govukButton({
+            text: "Create new",
+            classes: "govuk-button"
+          }) }}
+
+        </form>
       </div>
     </div>
   </div>
   {% endblock %}
+<form id="case-filters"  method="post">
 
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter mspsds-case-filter-controls">
+      <div class="mspsds-case-filter-controls__container">
+        <h2 class="govuk-heading-m mspsds-case-filter-controls__heading">Filters</h2>
 
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-bottom-2 mspsds-case-control mspsds-case-filter-controls">
-      <div class="govuk-!-margin-bottom-0">
+        <div class="mspsds-case-filter-controls__filters-container">
+          <div class="">
           {{ headerSearch({
             action: "./case-search",
             label: "Keywords",
             value: settings.q
           }) }}
+        </div>
+        
+        <div class="mspsds-case-control">
+        
+          {% set assigneeHtml %}
+            <label for="case-assignee-autocomplete" class="label govuk-label">Name / Team
+              <div id="case-assignee-autocomplete-container"></div>
+            </label>
+          {% endset -%}
+
+          {% set creatorHtml %}
+            <label for="case-creator-autocomplete" class="label govuk-label">Name / Team
+              <div id="case-creator-autocomplete-container"></div>
+            </label>
+          {% endset -%}
+          
+          {{ govukCheckboxes({
+
+              fieldset: {
+                legend: {
+                  text: "Assigned to",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              classes: "",
+              idPrefix:   "Assignee",
+              name:       "caseListSettings[assignee]",
+              items: [
+                {
+                  value: "Me",
+                  text: "Me",
+                  checked: checked("caseListSettings['assignee']", "Me")
+                },
+                {
+                  value: "my-team",
+                  text: "My team"
+                },
+                {
+                  value: "other",
+                  text: "Other person or team",
+                  checked: checked("caseListSettings['assignee']", "other"),
+                  conditional: {
+                    html: assigneeHtml
+                  }
+                }
+
+              ]
+            }) }}
+
+            {{ govukCheckboxes({
+
+              fieldset: {
+                legend: {
+                  text: "Created by",
+                  isPageHeading: false,
+                  classes: "govuk-fieldset__legend--s"
+                }
+              },
+              classes: "",
+              idPrefix:   "Creator",
+              name:       "caseListSettings[creator]",
+              items: [
+                {
+                  value: "Me",
+                  text: "Me",
+                  checked: checked("caseListSettings['creator']", "Me")
+                },
+                {
+                  value: "myTeam",
+                  text: "My team",
+                  checked: checked("caseListSettings['creator']", "MyTeam")
+                },
+                {
+                  value: "other",
+                  text: "Other person or team",
+                  checked: checked("caseListSettings['creator']", "other"),
+                  conditional: {
+                    html: creatorHtml
+                  }
+                }
+
+              ]
+            }) }}
+          
+          {# {% else %} #}
+          
+            
+
+          {# {% endif %} #}
+
+          {{ govukCheckboxes({
+            fieldset: {
+              legend: {
+                text: "Status",
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--s"
+              }
+            },
+            classes: "govuk-!-margin-bottom-5",
+            idPrefix: "Status",
+            name: "caseListSettings[status]",
+            items: [
+              {
+                value: "Open",
+                text: "Open",
+                checked: checked("caseListSettings['status']", "Open")
+              },
+              {
+                value: "Closed",
+                text: "Closed",
+                checked: checked("caseListSettings['status']", "Closed")
+              }
+            ]
+          }) }}
+
+          {# NB: filter by type doesn't work in prototype #}
+          {{ govukCheckboxes({
+            fieldset: {
+              legend: {
+                text: "Type",
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--s"
+              }
+            },
+            classes: "govuk-!-margin-bottom-5",
+            idPrefix: "Type",
+            name: "caseListSettings[type]",
+            items: [
+              {
+                value: "Case",
+                text: "Case",
+                checked: checked("caseListSettings['type']", "Case")
+              },
+              {
+                value: "Enquiry",
+                text: "Enquiry",
+                checked: checked("caseListSettings['type']", "Enquiry")
+              },
+              {
+                value: "Project",
+                text: "Project",
+                checked: checked("caseListSettings['type']", "Project")
+              }
+            ]
+          }) }}
+
+
+          {{ govukButton({
+            text: "Filter results"
+          }) }}
+
+        
+
+          <script type="text/javascript">
+            var users = {{ data.users | jsList | safe }}
+            
+            aElement = document.querySelector('#case-assignee-autocomplete-container');
+            accessibleAutocomplete({
+              element: aElement,
+              id: 'case-assignee-autocomplete',
+              name: "caseListSettings[assignee-other]",
+              showNoOptionsFound: false,
+              defaultValue: '{{data.caseListSettings["assignee-other"]}}',
+              showAllValues: true,
+              dropdownArrow: () => '',
+              source: users.sort()
+            });
+
+            cElement = document.querySelector('#case-creator-autocomplete-container');
+            accessibleAutocomplete({
+              element: cElement,
+              id: 'case-creator-autocomplete',
+              name: "caseListSettings[creator-other]",
+              showNoOptionsFound: false,
+              defaultValue: '{{data.caseListSettings["creator-other"]}}',
+              showAllValues: true,
+              dropdownArrow: () => '',
+              source: users.sort()
+            });
+
+          </script>
+        
+        </div>
+        </div>
+        
       </div>
 
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-      <form id="case-filters"  method="post">
-        {% set assigneeHtml %}
-          <label for="case-assignee-autocomplete" class="label govuk-label">Name / Team
-            <div id="case-assignee-autocomplete-container"></div>
-          </label>
-        {% endset -%}
-
-        {% set creatorHtml %}
-          <label for="case-creator-autocomplete" class="label govuk-label">Name / Team
-            <div id="case-creator-autocomplete-container"></div>
-          </label>
-        {% endset -%}
-        
-
-        {% if data['currentTeam'] == 'Trading Standards' %}
-          {{ govukCheckboxes({
-
-            fieldset: {
-              legend: {
-                text: "Created by",
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--s"
-              }
-            },
-            classes: "govuk-!-margin-bottom-5",
-            idPrefix:   "Creator",
-            name:       "tsCaseListSettings[creator]",
-            items: [
-              {
-                value: "Me",
-                text: "Me",
-                checked: checked("tsCaseListSettings['creator']", "Me")
-              },
-              {
-                value: "myTeam",
-                text: "My team",
-                checked: checked("tsCaseListSettings['creator']", "MyTeam")
-              },
-              {
-                value: "other",
-                text: "Other person or team",
-                checked: checked("tsCaseListSettings['creator']", "other"),
-                conditional: {
-                  html: creatorHtml
-                }
-              }
-
-            ]
-          }) }}
-        
-        {% else %}
-        
-          {{ govukCheckboxes({
-
-            fieldset: {
-              legend: {
-                text: "Assigned to",
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--s"
-              }
-            },
-            classes: "govuk-!-margin-bottom-5",
-            idPrefix:   "Assignee",
-            name:       "caseListSettings[assignee]",
-            items: [
-              {
-                value: "Me",
-                text: "Me",
-                checked: checked("caseListSettings['assignee']", "Me")
-              },
-              {
-                value: "other",
-                text: "Someone else",
-                checked: checked("caseListSettings['assignee']", "other"),
-                conditional: {
-                  html: assigneeHtml
-                }
-              }
-
-            ]
-          }) }}
-
-        {% endif %}
-
-        {{ govukCheckboxes({
-          fieldset: {
-            legend: {
-              text: "Status",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          classes: "govuk-!-margin-bottom-5",
-          idPrefix: "Status",
-          name: "caseListSettings[status]",
-          items: [
-            {
-              value: "Open",
-              text: "Open",
-              checked: checked("caseListSettings['status']", "Open")
-            },
-            {
-              value: "Closed",
-              text: "Closed",
-              checked: checked("caseListSettings['status']", "Closed")
-            }
-          ]
-        }) }}
-
-        {{ govukRadios({
-          fieldset: {
-            legend: {
-              text: "Sort by",
-              isPageHeading: false,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          classes: "govuk-!-margin-bottom-5",
-          idPrefix:   "Sort",
-          name:       "caseListSettings[sort]",
-          items: [
-            {
-              value: "latest",
-              text: "Updated: recent",
-              checked: checked("caseListSettings['sort']", "latest")
-            },
-            {
-              value: "oldest",
-              text: "Updated: oldest",
-              checked: checked("caseListSettings['sort']", "oldest")
-            },
-            {
-              value: "newest",
-              text: "Created: newest",
-              checked: checked("caseListSettings['sort']", "newest")
-            }
-          ]
-        }) }}
-
-        {{ govukButton({
-          text: "Apply filters"
-        }) }}
-
-      </form>
-
-      <script type="text/javascript">
-        var users = {{ data.users | jsList | safe }}
-        
-        aElement = document.querySelector('#case-assignee-autocomplete-container');
-        accessibleAutocomplete({
-          element: aElement,
-          id: 'case-assignee-autocomplete',
-          name: "caseListSettings[assignee-other]",
-          showNoOptionsFound: false,
-          defaultValue: '{{data.caseListSettings["assignee-other"]}}',
-          showAllValues: true,
-          dropdownArrow: () => '',
-          source: users.sort()
-        });
-
-        cElement = document.querySelector('#case-creator-autocomplete-container');
-        accessibleAutocomplete({
-          element: cElement,
-          id: 'case-creator-autocomplete',
-          name: "caseListSettings[creator-other]",
-          showNoOptionsFound: false,
-          defaultValue: '{{data.caseListSettings["creator-other"]}}',
-          showAllValues: true,
-          dropdownArrow: () => '',
-          source: users.sort()
-        });
-
-      </script>
-      
     </div>
-
-
-
 
     {% set searchClasses = '' %}
 
@@ -295,17 +284,115 @@
       {% endif %}
 
     {% endif %}
+    <div class="govuk-grid-column-three-quarters mspsds-case-list-tab {{searchClasses}}">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          {% if cases | length > 0 %}
+            <span class="govuk-heading-m">{{cases | length}} cases</span>
+          {% elseif cases | length == 0 %}
+            <span class="govuk-heading-m">No cases found</span>
+          {% endif %}
+
+          <p class="govuk-body"><a href="#" class="govuk-link govuk-link--no-visited-state opss-filter--hide">- Hide case filters</a></p>
+          
+          {# {{ govukButton({
+            text: "- Hide filters",
+            classes: "govuk-link govuk-link--no-visited-state opss-filter--hide"
+          }) }} #}
+        </div>
+        <div class="govuk-grid-column-one-half">
+          {% if cases | length > 1 %}
+            <span class="align-right">
+              {{ govukSelect({
+                id: "sort",
+                name: "sort",
+                formGroup: {
+                  classes: "govuk-!-margin-bottom-4"
+                },
+                label: {
+                  text: "Sort by"
+                },
+                items: [
+                  {
+                    value: "published",
+                    text: "Recently created"
+                  },
+                  {
+                    value: "updated",
+                    text: "Recently updated",
+                    selected: true
+                  },
+                  {
+                    value: "creator",
+                    text: "Creator"
+                  },
+                  {
+                    value: "assignee",
+                    text: "Assignee"
+                  },
+                  {
+                    value: "title",
+                    text: "Title"
+                  }
+                ]
+              }) }}
+            </span>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="facet-tags" data-module="track-click">
+        <div class="facet-tags__group">
+          <div class="facet-tags__wrapper">
+            <p class="facet-tags__preposition">Assigned to</p>
+            <div class="facet-tag">
+              <p class="facet-tag__text">You</p>
+              <button type="button" class="facet-tag__remove" aria-label="Remove filter CA98 and civil cartels" data-module="remove-filter-link" data-facet="case_type" data-value="ca98-and-civil-cartels" data-name="">✕</button>
+            </div>
+          </div>
+        {# <div class="facet-tags__wrapper">
+            <p class="facet-tags__preposition"> or </p>
+            <div class="facet-tag">
+              <p class="facet-tag__text">Competition disqualification</p>
+              <button type="button" class="facet-tag__remove" aria-label="Remove filter Competition disqualification" data-module="remove-filter-link" data-facet="case_type" data-value="competition-disqualification" data-name="">✕</button>
+            </div>
+          </div> #}
+      </div>
+        <div class="facet-tags__group">
+          <div class="facet-tags__wrapper">
+            <p class="facet-tags__preposition">Status</p>
+            <div class="facet-tag">
+              <p class="facet-tag__text">Open</p>
+              <button type="button" class="facet-tag__remove" aria-label="Remove filter CA98 - no grounds for action" data-module="remove-filter-link" data-facet="outcome_type" data-value="ca98-no-grounds-for-action-non-infringement" data-name="">✕</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {% set caseListCases = cases | attachCaseChildren(data) %}
+
+      {% if caseListCases | length > 0 %}
+      
+        {% from "includes/components/case/case-card-list.html"          import caseCardList %}
+        {{ caseCardList(caseListCases, data.currentTeam, search)}}
+
+      {% endif %}
+    </div>
+    
+    
+  </div>
+  <div class="govuk-grid-row">
 
 
+    
+
+    
 
     <div class="govuk-grid-column-three-quarters mspsds-case-list-tab {{searchClasses}}">
-      {% from "includes/components/case/case-card-list.html"          import caseCardList %}
-      {{ caseCardList(cases | attachCaseChildren(data), data.currentTeam, search) }}
-      {% if cases | length == 0 %}
-          <span class="govuk-heading-xl">No results</span>
-      {% endif %}
+
+      
     </div>
 
   </div>
-
+</form>
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -15,6 +15,7 @@
 {% from "panel/macro.njk"         import govukPanel %}
 {% from "phase-banner/macro.njk"  import govukPhaseBanner %}
 {% from "radios/macro.njk"        import govukRadios %}
+{% from "summary-list/macro.njk" import govukSummaryList %}
 {% from "select/macro.njk"        import govukSelect %}
 {% from "skip-link/macro.njk"     import govukSkipLink %}
 {% from "table/macro.njk"         import govukTable %}

--- a/app/views/pages/flows/send-alert/compose-alert.html
+++ b/app/views/pages/flows/send-alert/compose-alert.html
@@ -42,7 +42,7 @@
           id: "more-detail",
           rows: "12",
           label: {
-            text: "Alert content",
+            text: "Alert summary",
             classes: "govuk-label--m"
           },
           hint: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-writer": "0.0.4",
     "govuk-country-and-territory-autocomplete": "^0.5.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.0.0",
+    "govuk-frontend": "^2.9.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
A bunch of changes to change the look of the caselist page, including:
* Using a table rather than cards for main layout
* Adding several options for filtering (non functional in prototype)
* Moving sorting
* WIP for being able to hide the filters