### PR TITLE
Add service status banner

### DIFF
--- a/app/views/includes/components/shared/service-status-banner.html
+++ b/app/views/includes/components/shared/service-status-banner.html
@@ -1,0 +1,19 @@
+{% from "includes/components/shared/hmcts-banner.html" import hmctsBanner %}
+
+
+{# Banner for problems #}
+{% set bannerHtml %}
+  <h2 class="govuk-heading-s">We’re aware of intermittent problems with the service</h2>
+  {# <p class="govuk-body"></p> #}
+  <p class="govuk-body">Thank you for your patience while we investigate.</p>
+  <p class="govuk-body">(Last updated 23 September 2019)</p>
+{% endset %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  {{ hmctsBanner({
+    html: bannerHtml
+  }) }}
+  </div>
+</div>
+{# / end banner for problems #}

--- a/app/views/includes/templates/home-ts.html
+++ b/app/views/includes/templates/home-ts.html
@@ -19,7 +19,6 @@
 {% set navActive = 'home' %}
 
 
-
 {% block beforeContent %}
 
 
@@ -90,12 +89,15 @@
 
 {% block content %}
 
-
+{# Manually set to see banner #}
+{% if data.stabilityIssues %}
+{% include "includes/components/shared/service-status-banner.html" %}
+{% endif %}
 
 <section class="mspsds-pagetitle">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% from "includes/components/shared/page-title.html"        import pageTitle %}
+      {% from "includes/components/shared/page-title.html" import pageTitle %}
       {{ pageTitle({
         title: serviceName
       }) }}


### PR DESCRIPTION
Add a conditional banner for telling users about stability issues:

![Screenshot 2019-10-07 at 12 02 10](https://user-images.githubusercontent.com/2204224/66306741-578f7c00-e8fa-11e9-8295-ddaca170bcf0.png)

Set `stabilityIssues` to `true` to see.