### PR TITLE
Add digital marketplace style banners

### DIFF
--- a/app/assets/sass/_notification-banner.scss
+++ b/app/assets/sass/_notification-banner.scss
@@ -1,0 +1,98 @@
+// GOV.UK orange doesn't pass colour contrast when used on a white background
+// This darkens it to the point where it passes WCAG 2 AAA at 18pt and above
+$accessible-orange: darken(govuk-colour("orange"), 16.5%);
+
+.app-banner {
+
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(3, "top");
+  @include govuk-responsive-margin(7, "bottom");
+
+  border-width: 5px;
+  border-style: solid;
+  color: $govuk-brand-colour; // default colour
+}
+
+.app-banner__action {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+}
+
+.app-banner__heading {
+
+  margin-top: govuk-spacing(0);
+  margin-bottom: govuk-responsive-margin(4, "bottom");
+
+  @include govuk-font(36, $weight:bold);
+  color: inherit;
+
+}
+
+.app-banner__message {
+
+  @include govuk-font(24, $weight:bold);
+
+  &,
+  a:link,
+  a:active,
+  a:visited {
+    color: inherit;
+  }
+
+  a:focus,
+  a:hover:focus {
+    // @include govuk-focused-text;
+    color: $govuk-text-colour;
+  }
+
+  a:hover {
+    text-decoration: none;
+  }
+
+  &:last-of-type {
+    margin-bottom: govuk-spacing(0);
+  }
+
+}
+
+// Different coloured banners
+.app-banner--destructive {
+  color: $govuk-error-colour;
+}
+
+.app-banner--information {
+  color: $govuk-brand-colour;
+}
+
+.app-banner--success {
+  color: govuk-colour("green"); // same as button colour
+}
+
+.app-banner--warning {
+  color: $accessible-orange;
+}
+
+// Inverted banner style
+.app-banner--temporary-message {
+
+  border: none;
+  background: $govuk-brand-colour;
+
+  &,
+  a:link,
+  a:active,
+  a:visited {
+    color: govuk-colour("white");
+  }
+
+  a:focus,
+  a:hover:focus {
+    // @include govuk-focused-text;
+    color: $govuk-text-colour;
+  }
+
+  .app-banner__message {
+    @include govuk-font(19, $weight:regular);
+  }
+
+}

--- a/app/assets/sass/_notification-banner.scss
+++ b/app/assets/sass/_notification-banner.scss
@@ -41,6 +41,7 @@ $accessible-orange: darken(govuk-colour("orange"), 16.5%);
 
   a:focus,
   a:hover:focus {
+    // Swap these lines if using govuk-frontend 3.0 or greater:
     // @include govuk-focused-text;
     color: $govuk-text-colour;
   }
@@ -87,6 +88,7 @@ $accessible-orange: darken(govuk-colour("orange"), 16.5%);
 
   a:focus,
   a:hover:focus {
+    // Swap these lines if using govuk-frontend 3.0 or greater:
     // @include govuk-focused-text;
     color: $govuk-text-colour;
   }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -35,6 +35,7 @@ $govuk-page-width: 1200px;
 @import "hmcts-sub-navigation";
 @import "interruption-card";
 @import "facet-tags";
+@import "notification-banner";
 @import "teams";
 @import "footer";
 @import "email-message";

--- a/app/views/includes/components/shared/notification-banner.html
+++ b/app/views/includes/components/shared/notification-banner.html
@@ -1,0 +1,18 @@
+
+{% macro notificationBanner(params) %}
+  <div class="app-banner app-banner--{{ params.type }} app-banner--{% if params.action %}with-action{% else %}without-action{% endif %} {{ classes if params.classes}}">
+    {% if params.heading %}
+      <h2 class="app-banner__heading">
+        {{ params.heading }}
+      </h2>
+    {% endif %}
+
+    {% if params.html %}
+      {{params.html | safe}}
+    {% elseif params.text %}
+      <p class="app-banner__message">{{ params.text }}</p>
+    {% endif %}
+    {{ params.action }}
+  </div>
+
+{% endmacro %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -42,6 +42,7 @@
 {% from "includes/components/shared/big-number.html" import bigNumberDark %}
 {% from "includes/components/shared/big-number.html" import bigNumberWithStatus %}
 {% from "includes/components/shared/permission-notice.html" import permissionNotice %}
+{% from "includes/components/shared/notification-banner.html" import notificationBanner %}
 
 {% if data['signedIn'] == 'Yes' %}
   {% set headerNav = [


### PR DESCRIPTION
Adds [Digital Marketplace style notification banners](http://alphagov.github.io/digitalmarketplace-frontend-toolkit/notification-banner.html).

<img width="876" alt="Screenshot 2020-04-01 at 12 21 14" src="https://user-images.githubusercontent.com/2204224/78131715-6ec7a600-7413-11ea-822b-c56769de85f5.png">

Changes from the Digital Marketplace banners:

* Uses design system colours and spacing.
* More BEM compliant.
* Link colour matches text colour.

## GOV.UK Frontend 3.0

This prototype doesn't have the latest GOV.UK Frontend so I've commented out the focus styles. For later gov.uk frontend these should be un-commented and the relevant colour declarations for focus removed.